### PR TITLE
Ignore malformed PortInfo entries

### DIFF
--- a/cm_test.go
+++ b/cm_test.go
@@ -81,7 +81,8 @@ func TestCMDsInfo(t *testing.T) {
 		"dsoctets":"4829493","correcteds":"0","uncorrect":"0"},
 		{"portId":"2","frequency":"603000000","modulation":"QAM256",
 		"signalStrength":"2.000","snr":"37.636","channelId":"9",
-		"dsoctets":"4960133","correcteds":"0","uncorrect":"0"}
+		"dsoctets":"4960133","correcteds":"0","uncorrect":"0"},
+		{"signalStrength":false,"snr":true}
 	]}`
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cm_types_test.go
+++ b/cm_types_test.go
@@ -1,6 +1,7 @@
 package hitron
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -27,4 +28,100 @@ func TestParseDHCPLeaseTime(t *testing.T) {
 			assert.Equal(t, d.dur, out)
 		})
 	}
+}
+
+func TestPortInfoUnmarshalJSON(t *testing.T) {
+	in := `{
+	"portId": "1",
+	"frequency": "615000000",
+	"modulation": "QAM256",
+	"signalStrength": "2.500",
+	"snr": "37.636",
+	"channelId": "11",
+	"dsoctets": "20883398",
+	"correcteds": "1",
+	"uncorrect": "0"
+}`
+	expected := &PortInfo{
+		PortID:         "1",
+		Frequency:      615000000,
+		Modulation:     "QAM256",
+		SignalStrength: 2.5,
+		ChannelID:      "11",
+		SNR:            37.636,
+		DsOctets:       20883398,
+		Correcteds:     1,
+		Uncorrect:      0,
+	}
+	out := &PortInfo{}
+	err := json.Unmarshal([]byte(in), out)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, out)
+
+	in = `{
+	"portId": "8",
+	"frequency": "",
+	"modulation": "QAM256",
+	"signalStrength": false,
+	"snr": false,
+	"channelId": "0",
+	"dsoctets": "0",
+	"correcteds": "0",
+	"uncorrect": "0"
+}`
+	out = &PortInfo{}
+	err = json.Unmarshal([]byte(in), out)
+	assert.Error(t, err)
+}
+
+func TestCMDsInfoUnmarshalJSON(t *testing.T) {
+	in := `{
+	"errCode": "000",
+	"errMsg": "",
+	"Freq_List": [
+		{
+		"portId": "1",
+		"frequency": "615000000",
+		"modulation": "QAM256",
+		"signalStrength": "2.500",
+		"snr": "37.636",
+		"channelId": "11",
+		"dsoctets": "20883398",
+		"correcteds": "1",
+		"uncorrect": "0"
+		},
+		{
+		"portId": "8",
+		"frequency": "",
+		"modulation": "QAM256",
+		"signalStrength": false,
+		"snr": false,
+		"channelId": "0",
+		"dsoctets": "0",
+		"correcteds": "0",
+		"uncorrect": "0"
+		}
+	]
+}`
+	expected := &CMDsInfo{
+		Error: NoError,
+		Ports: []PortInfo{
+			{
+				PortID:         "1",
+				Frequency:      615000000,
+				Modulation:     "QAM256",
+				SignalStrength: 2.5,
+				ChannelID:      "11",
+				SNR:            37.636,
+				DsOctets:       20883398,
+				Correcteds:     1,
+				Uncorrect:      0,
+			},
+		},
+	}
+
+	out := &CMDsInfo{}
+	err := json.Unmarshal([]byte(in), out)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, out)
 }


### PR DESCRIPTION
Sometimes, for some reason, the `signalStrength` and `snr` properties return `false`, which causes parsing to fail. That's OK for the individual `PortInfo`, but when I'm dealing with a list of 32 of them I'd prefer to miss a few than not get any of them.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>