### PR TITLE
feat(logging)!: Switch from go-kit/log to log/slog

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ fmt.Printf("Private LAN IP: %s\n", info.PrivLanIP)
 
 [The MIT License](http://opensource.org/licenses/MIT)
 
-Copyright (c) 2020-2021 Dave Henderson
+Copyright (c) 2020-2024 Dave Henderson

--- a/admin_test.go
+++ b/admin_test.go
@@ -15,7 +15,7 @@ func TestCMReboot(t *testing.T) {
 	srv := staticResponseServer(t, body)
 
 	d := testCableModem(srv)
-	ctx := ContextWithDebugLogger(context.Background(), t)
+	ctx := context.Background()
 
 	o, err := d.CMReboot(ctx)
 	assert.NoError(t, err)

--- a/cmd/hitron/main.go
+++ b/cmd/hitron/main.go
@@ -8,24 +8,14 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	hitron "github.com/hairyhenderson/hitron_coda"
 )
-
-type debugLogAdapter struct {
-	log.Logger
-}
-
-func (l debugLogAdapter) Logf(format string, args ...interface{}) {
-	_ = l.Log("msg", fmt.Sprintf(format, args...))
-}
 
 type opts struct {
 	host     string
 	username string
 	password string
-	logLevel Level
+	logLevel LevelValue
 }
 
 func flags(args []string, o *opts) ([]string, error) {
@@ -91,9 +81,7 @@ func run(args []string) error {
 		return err
 	}
 
-	logger := NewLogger(o.logLevel)
-	debugLogger := debugLogAdapter{level.Debug(logger)}
-	ctx = hitron.ContextWithDebugLogger(ctx, debugLogger)
+	initLogger(o.logLevel)
 
 	cm, err := hitron.New(o.host, o.username, o.password)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,16 +1,14 @@
 module github.com/hairyhenderson/hitron_coda
 
-go 1.19
+go 1.22.3
 
 require (
-	github.com/go-kit/log v0.2.1
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/text v0.15.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,5 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
-github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
-github.com/go-logfmt/logfmt v0.6.0 h1:wGYYu3uicYdqXVgoYbvnkrPVXkuLM1p1ifugDMEdRi4=
-github.com/go-logfmt/logfmt v0.6.0/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/misc_test.go
+++ b/misc_test.go
@@ -44,7 +44,7 @@ func TestDNS(t *testing.T) {
 	srv := staticResponseServer(t, body)
 	d := testCableModem(srv)
 
-	ctx := ContextWithDebugLogger(context.Background(), t)
+	ctx := context.Background()
 
 	p, err := d.DNS(ctx)
 	assert.NoError(t, err)
@@ -71,7 +71,7 @@ func TestDDNS(t *testing.T) {
 	srv := staticResponseServer(t, body)
 	d := testCableModem(srv)
 
-	ctx := ContextWithDebugLogger(context.Background(), t)
+	ctx := context.Background()
 
 	p, err := d.DDNS(ctx)
 	assert.NoError(t, err)
@@ -103,7 +103,7 @@ func TestHosts(t *testing.T) {
 	srv := staticResponseServer(t, body)
 	d := testCableModem(srv)
 
-	ctx := ContextWithDebugLogger(context.Background(), t)
+	ctx := context.Background()
 
 	p, err := d.Hosts(ctx)
 	assert.NoError(t, err)
@@ -143,7 +143,7 @@ func TestUsersCSRF(t *testing.T) {
 	srv := staticResponseServer(t, body)
 
 	d := testCableModem(srv)
-	ctx := ContextWithDebugLogger(context.Background(), t)
+	ctx := context.Background()
 
 	p, err := d.UsersCSRF(ctx)
 	assert.NoError(t, err)

--- a/wifi_test.go
+++ b/wifi_test.go
@@ -18,7 +18,7 @@ func TestWiFiAccessControl(t *testing.T) {
 	srv := staticResponseServer(t, body)
 	d := testCableModem(srv)
 
-	ctx := ContextWithDebugLogger(context.Background(), t)
+	ctx := context.Background()
 
 	p, err := d.WiFiAccessControl(ctx)
 	assert.NoError(t, err)
@@ -38,7 +38,7 @@ func TestWiFiAccessControlStatus(t *testing.T) {
 	srv := staticResponseServer(t, body)
 	d := testCableModem(srv)
 
-	ctx := ContextWithDebugLogger(context.Background(), t)
+	ctx := context.Background()
 
 	p, err := d.WiFiAccessControlStatus(ctx)
 	assert.NoError(t, err)
@@ -59,7 +59,7 @@ func TestWiFiGuestSSID(t *testing.T) {
 	srv := staticResponseServer(t, body)
 	d := testCableModem(srv)
 
-	ctx := ContextWithDebugLogger(context.Background(), t)
+	ctx := context.Background()
 
 	p, err := d.WiFiGuestSSID(ctx)
 	assert.NoError(t, err)
@@ -94,7 +94,7 @@ func TestWiFiRadios(t *testing.T) {
 	srv := staticResponseServer(t, body)
 	d := testCableModem(srv)
 
-	ctx := ContextWithDebugLogger(context.Background(), t)
+	ctx := context.Background()
 
 	p, err := d.WiFiRadios(ctx)
 	assert.NoError(t, err)
@@ -141,7 +141,7 @@ func TestWiFiRadioDetails(t *testing.T) {
 	srv := staticResponseServer(t, body)
 	d := testCableModem(srv)
 
-	ctx := ContextWithDebugLogger(context.Background(), t)
+	ctx := context.Background()
 
 	p, err := d.WiFiRadioDetails(ctx, 2)
 	assert.NoError(t, err)
@@ -192,7 +192,7 @@ func TestWiFiRadiosAdvanced(t *testing.T) {
 	srv := staticResponseServer(t, body)
 	d := testCableModem(srv)
 
-	ctx := ContextWithDebugLogger(context.Background(), t)
+	ctx := context.Background()
 
 	p, err := d.WiFiRadiosAdvanced(ctx)
 	assert.NoError(t, err)
@@ -278,7 +278,7 @@ func TestWiFiRadiosSurvey(t *testing.T) {
 	srv := staticResponseServer(t, body)
 	d := testCableModem(srv)
 
-	ctx := ContextWithDebugLogger(context.Background(), t)
+	ctx := context.Background()
 
 	p, err := d.WiFiRadiosSurvey(ctx)
 	assert.NoError(t, err)
@@ -328,7 +328,7 @@ func TestWiFiSSIDs(t *testing.T) {
 	srv := staticResponseServer(t, body)
 	d := testCableModem(srv)
 
-	ctx := ContextWithDebugLogger(context.Background(), t)
+	ctx := context.Background()
 
 	p, err := d.WiFiSSIDs(ctx)
 	assert.NoError(t, err)
@@ -370,7 +370,7 @@ func TestWiFiWPS(t *testing.T) {
 	srv := staticResponseServer(t, body)
 	d := testCableModem(srv)
 
-	ctx := ContextWithDebugLogger(context.Background(), t)
+	ctx := context.Background()
 
 	p, err := d.WiFiWPS(ctx)
 	assert.NoError(t, err)
@@ -400,7 +400,7 @@ func TestWiFiClient(t *testing.T) {
 	srv := staticResponseServer(t, body)
 	d := testCableModem(srv)
 
-	ctx := ContextWithDebugLogger(context.Background(), t)
+	ctx := context.Background()
 
 	p, err := d.WiFiClient(ctx)
 	assert.NoError(t, err)


### PR DESCRIPTION
Switches from go-kit/log to `log/slog`.

As part of this, the `ContextWithDebugLogger` function is removed and instead the debug transport is enabled when the default `slog` logger has debug level set.