### PR TITLE
fix(lint): Expand packet fields in router.Sysinfo to uint64

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,11 +18,11 @@ linters:
   enable:
     - asciicheck
     - bodyclose
+    - copyloopvar
     - dogsled
     - dupl
     - errcheck
     - exhaustive
-    - exportloopref
     - funlen
     - gci
     - gochecknoglobals

--- a/cm_types_test.go
+++ b/cm_types_test.go
@@ -22,7 +22,6 @@ func TestParseDHCPLeaseTime(t *testing.T) {
 	}
 
 	for _, d := range testdata {
-		d := d
 		t.Run(d.in, func(t *testing.T) {
 			out := parseDHCPLeaseDuration(d.in)
 			assert.Equal(t, d.dur, out)

--- a/hitron.go
+++ b/hitron.go
@@ -158,6 +158,12 @@ func atoi64(s string) int64 {
 	return i
 }
 
+func atoui64(s string) uint64 {
+	i, _ := strconv.ParseUint(strings.TrimSpace(s), 10, 64)
+
+	return i
+}
+
 func atof64(s string) float64 {
 	f, _ := strconv.ParseFloat(strings.TrimSpace(s), 64)
 
@@ -175,34 +181,34 @@ const (
 	eib
 )
 
-func formattedBytesToInt64(s string) int64 {
-	i, err := strconv.ParseInt(strings.TrimSpace(s), 10, 64)
+func formattedBytesToUint64(s string) uint64 {
+	i, err := strconv.ParseUint(strings.TrimSpace(s), 10, 64)
 	if err == nil {
 		return i
 	}
 
 	s = strings.TrimSuffix(s, " Bytes")
 	if len(s) <= 1 {
-		return atoi64(s)
+		return atoui64(s)
 	}
 
 	switch s[len(s)-1] {
 	case 'B':
-		i = int64(atof64(s[:len(s)-1]))
+		i = uint64(atof64(s[:len(s)-1]))
 	case 'K':
-		i = int64(atof64(s[:len(s)-1]) * kib)
+		i = uint64(atof64(s[:len(s)-1]) * kib)
 	case 'M':
-		i = int64(atof64(s[:len(s)-1]) * mib)
+		i = uint64(atof64(s[:len(s)-1]) * mib)
 	case 'G':
-		i = int64(atof64(s[:len(s)-1]) * gib)
+		i = uint64(atof64(s[:len(s)-1]) * gib)
 	case 'T':
-		i = int64(atof64(s[:len(s)-1]) * tib)
+		i = uint64(atof64(s[:len(s)-1]) * tib)
 	case 'P':
-		i = int64(atof64(s[:len(s)-1]) * pib)
+		i = uint64(atof64(s[:len(s)-1]) * pib)
 	case 'E':
-		i = int64(atof64(s[:len(s)-1]) * eib)
+		i = uint64(atof64(s[:len(s)-1]) * eib)
 	default:
-		i = int64(atof64(s))
+		i = uint64(atof64(s))
 	}
 
 	return i

--- a/hitron_test.go
+++ b/hitron_test.go
@@ -57,22 +57,22 @@ func TestURL(t *testing.T) {
 	assert.EqualValues(t, expected, u)
 }
 
-func TestFormattedBytesToInt64(t *testing.T) {
-	assert.Equal(t, int64(0), formattedBytesToInt64(""))
-	assert.Equal(t, int64(0), formattedBytesToInt64("0"))
-	assert.Equal(t, int64(0), formattedBytesToInt64("0 Bytes"))
-	assert.Equal(t, int64(0), formattedBytesToInt64("0M Bytes"))
-	assert.Equal(t, int64(0), formattedBytesToInt64("0.0G Bytes"))
+func TestFormattedBytesToUint64(t *testing.T) {
+	assert.Equal(t, uint64(0), formattedBytesToUint64(""))
+	assert.Equal(t, uint64(0), formattedBytesToUint64("0"))
+	assert.Equal(t, uint64(0), formattedBytesToUint64("0 Bytes"))
+	assert.Equal(t, uint64(0), formattedBytesToUint64("0M Bytes"))
+	assert.Equal(t, uint64(0), formattedBytesToUint64("0.0G Bytes"))
 
-	assert.Equal(t, int64(1), formattedBytesToInt64("1"))
-	assert.Equal(t, int64(1), formattedBytesToInt64("1B"))
-	assert.Equal(t, int64(1), formattedBytesToInt64("1B Bytes"))
-	assert.Equal(t, int64(42), formattedBytesToInt64("42 Bytes"))
-	assert.Equal(t, int64(kib), formattedBytesToInt64("1.0K Bytes"))
-	assert.Equal(t, int64(2*mib), formattedBytesToInt64("2.0M Bytes"))
+	assert.Equal(t, uint64(1), formattedBytesToUint64("1"))
+	assert.Equal(t, uint64(1), formattedBytesToUint64("1B"))
+	assert.Equal(t, uint64(1), formattedBytesToUint64("1B Bytes"))
+	assert.Equal(t, uint64(42), formattedBytesToUint64("42 Bytes"))
+	assert.Equal(t, uint64(kib), formattedBytesToUint64("1.0K Bytes"))
+	assert.Equal(t, uint64(2*mib), formattedBytesToUint64("2.0M Bytes"))
 
 	// 18.65 * 1TiB == 20505891858022.4, truncated to 20505891858022
-	assert.Equal(t, int64(20505891858022), formattedBytesToInt64("18.65T Bytes"))
+	assert.Equal(t, uint64(20505891858022), formattedBytesToUint64("18.65T Bytes"))
 }
 
 func TestByteSize(t *testing.T) {

--- a/router_types.go
+++ b/router_types.go
@@ -28,12 +28,12 @@ type RouterSysInfo struct {
 	RFMac           net.HardwareAddr // :"74:9B:DE:AD:BE:EF",
 	SystemLanUptime time.Duration    // : "468117",
 	SystemWanUptime time.Duration    // :"468083",
-	LanRx           int64            // :"19601748772",
-	LanTx           int64            // :"141585555187",
-	WanRx           int64            // :"139788502458",
-	WanRxPkts       int64            // :"175946286",
-	WanTx           int64            // :"18787516468",
-	WanTxPkts       int64            // :"52845543",
+	LanRx           uint64           // :"19601748772",
+	LanTx           uint64           // :"141585555187",
+	WanRx           uint64           // :"139788502458",
+	WanRxPkts       uint64           // :"175946286",
+	WanTx           uint64           // :"18787516468",
+	WanTxPkts       uint64           // :"52845543",
 }
 
 //nolint:funlen
@@ -72,9 +72,9 @@ func (s RouterSysInfo) String() string {
 	sb.WriteString(")\n")
 
 	sb.WriteString("	Rx/Tx: ")
-	sb.WriteString(byteSize(uint64(s.LanRx)))
+	sb.WriteString(byteSize(s.LanRx))
 	sb.WriteString("/")
-	sb.WriteString(byteSize(uint64(s.LanTx)))
+	sb.WriteString(byteSize(s.LanTx))
 	sb.WriteString("\n")
 
 	sb.WriteString("WAN: ")
@@ -92,9 +92,9 @@ func (s RouterSysInfo) String() string {
 	sb.WriteString(")\n")
 
 	sb.WriteString("	Rx/Tx: ")
-	sb.WriteString(byteSize(uint64(s.WanRx)))
+	sb.WriteString(byteSize(s.WanRx))
 	sb.WriteString("/")
-	sb.WriteString(byteSize(uint64(s.WanTx)))
+	sb.WriteString(byteSize(s.WanTx))
 	sb.WriteString("\n")
 
 	sb.WriteString("	Rx/Tx Packets: ")
@@ -213,12 +213,12 @@ func (s *RouterSysInfo) UnmarshalJSON(b []byte) error {
 		return fmt.Errorf("failed to parse CIDR %q: %w", raw.PrivLanIP, err)
 	}
 
-	s.LanRx = formattedBytesToInt64(raw.LanRx)
-	s.LanTx = formattedBytesToInt64(raw.LanTx)
-	s.WanRx = formattedBytesToInt64(raw.WanRx)
-	s.WanRxPkts = atoi64(raw.WanRxPkts)
-	s.WanTx = formattedBytesToInt64(raw.WanTx)
-	s.WanTxPkts = atoi64(raw.WanTxPkts)
+	s.LanRx = formattedBytesToUint64(raw.LanRx)
+	s.LanTx = formattedBytesToUint64(raw.LanTx)
+	s.WanRx = formattedBytesToUint64(raw.WanRx)
+	s.WanRxPkts = atoui64(raw.WanRxPkts)
+	s.WanTx = formattedBytesToUint64(raw.WanTx)
+	s.WanTxPkts = atoui64(raw.WanTxPkts)
 
 	lanUp, err := parseUptime(raw.SystemLanUptime)
 	if err != nil {

--- a/wifi_types_test.go
+++ b/wifi_types_test.go
@@ -26,7 +26,6 @@ func TestWiFiModeString(t *testing.T) {
 	}
 
 	for _, d := range testdata {
-		d := d
 		t.Run(d.expected, func(t *testing.T) {
 			assert.Equal(t, d.expected, d.in.String())
 		})


### PR DESCRIPTION
Counters shouldn't need to be negative, plus there's a risk of overflow. Also fixing some other minor lint issues.